### PR TITLE
dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dynamic = ["version"]
 elasticsearch = [
     "elasticsearch<8"
 ]
+webapi = [
+    "feedparser",
+]
 
 [build-system]
 requires = ["setuptools", "setuptools-scm"]


### PR DESCRIPTION
While developing, the dependencies became out-of-sync. This adds a bunch of undeclared dependencies, as well as optional dependencies for the `webapi`.