### PR TITLE
use `hostname` instead of `host`

### DIFF
--- a/stac_fastapi/opensearx/elasticsearch/__main__.py
+++ b/stac_fastapi/opensearx/elasticsearch/__main__.py
@@ -75,10 +75,6 @@ else:
         "http_auth": auth,
     }
 
-    import pathlib
-
-    print(list(pathlib.Path("/app").iterdir()))
-
 api = create_api(
     credentials=credentials,
     dialect=args.dialect,

--- a/stac_fastapi/opensearx/elasticsearch/__main__.py
+++ b/stac_fastapi/opensearx/elasticsearch/__main__.py
@@ -75,6 +75,10 @@ else:
         "http_auth": auth,
     }
 
+    import pathlib
+
+    print(list(pathlib.Path("/app").iterdir()))
+
 api = create_api(
     credentials=credentials,
     dialect=args.dialect,

--- a/stac_fastapi/opensearx/elasticsearch/__main__.py
+++ b/stac_fastapi/opensearx/elasticsearch/__main__.py
@@ -69,7 +69,7 @@ else:
         auth = f"{user}:{passwd}"
 
     credentials = {
-        "host": parts.host,
+        "host": parts.hostname,
         "port": parts.port,
         "use_ssl": True,
         "http_auth": auth,


### PR DESCRIPTION
This is a typo, the result of `urlsplit` only has a `hostname` attribute.