### PR TITLE
update the dependencies of the `elasticsearch` backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 elasticsearch = [
-    "elasticsearch<8"
+    "elasticsearch<8",
+    "odc-geo",
 ]
 webapi = [
     "feedparser",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dynamic = ["version"]
 elasticsearch = [
     "elasticsearch<8",
     "odc-geo",
+    "dateutil",
 ]
 webapi = [
     "feedparser",


### PR DESCRIPTION
It seems I forgot to add `odc-geo` and `dateutil` to the optional dependencies.