### PR TITLE
fix the distribution name of `dateutil`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["version"]
 elasticsearch = [
     "elasticsearch<8",
     "odc-geo",
-    "dateutil",
+    "python-dateutil",
 ]
 webapi = [
     "feedparser",


### PR DESCRIPTION
Apparently, it is called `python-dateutil` instead of just `dateutil` (the name would be available, though).